### PR TITLE
Release 0.4.0

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -2,11 +2,11 @@ name: CI
 
 on:
   push:
-    branches: [main]
+    branches: [main, dev]
   pull_request:
 
 jobs:
-  build:
+  package:
     runs-on: ubuntu-latest
     strategy:
       matrix:
@@ -17,8 +17,24 @@ jobs:
         with:
           sdk: ${{ matrix.sdk }}
       - run: dart pub get
-      - run: dart format --output=none --set-exit-if-changed .
-      - run: dart analyze --fatal-infos
+      # Scoped to the package: example_app is a Flutter project with its own
+      # SDK/formatter and is checked by the demo-app job below.
+      - run: dart format --output=none --set-exit-if-changed lib bin test example
+      - run: dart analyze --fatal-infos lib bin test example
       - run: dart test
       - run: dart pub publish --dry-run
         if: matrix.sdk == 'stable'
+
+  demo-app:
+    runs-on: ubuntu-latest
+    defaults:
+      run:
+        working-directory: example_app
+    steps:
+      - uses: actions/checkout@v4
+      - uses: subosito/flutter-action@v2
+        with:
+          channel: stable
+      - run: flutter pub get
+      - run: flutter analyze
+      - run: flutter test

--- a/.github/workflows/dev-release.yaml
+++ b/.github/workflows/dev-release.yaml
@@ -1,0 +1,39 @@
+name: Dev prerelease
+
+# The dev channel: any push to dev whose pubspec carries a -dev.N prerelease
+# version that has not been tagged yet gets tagged and published to pub.dev
+# automatically. Stable versions on dev are ignored — stable releases are
+# tagged manually on main.
+on:
+  push:
+    branches: [dev]
+
+permissions:
+  contents: write # create the release tag
+  actions: write # dispatch the publish workflow
+
+jobs:
+  tag-and-publish:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - id: version
+        run: |
+          echo "version=$(sed -n 's/^version: *//p' pubspec.yaml)" >> "$GITHUB_OUTPUT"
+      - name: Tag and dispatch publish
+        if: contains(steps.version.outputs.version, '-dev.')
+        env:
+          GH_TOKEN: ${{ github.token }}
+          VERSION: ${{ steps.version.outputs.version }}
+        run: |
+          TAG="v$VERSION"
+          if gh api "repos/$GITHUB_REPOSITORY/git/ref/tags/$TAG" >/dev/null 2>&1; then
+            echo "Tag $TAG already exists; nothing to publish."
+            exit 0
+          fi
+          git tag "$TAG"
+          git push origin "$TAG"
+          # Tags pushed with GITHUB_TOKEN do not trigger tag workflows
+          # (recursion guard), so dispatch the publish workflow on the tag
+          # ref explicitly — pub.dev's OIDC check needs the tag ref.
+          gh workflow run publish.yaml --ref "$TAG"

--- a/.github/workflows/publish.yaml
+++ b/.github/workflows/publish.yaml
@@ -3,6 +3,9 @@ name: Publish to pub.dev
 on:
   push:
     tags: ['v[0-9]+.[0-9]+.[0-9]+*']
+  # Dispatched on a tag ref by dev-release.yaml (tags pushed with
+  # GITHUB_TOKEN do not fire tag-push workflows themselves).
+  workflow_dispatch:
 
 jobs:
   publish:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,10 @@
   parameter type (with a count) instead of one per curve.
 - Roadmap: playback and the Flutter companion package were removed; the demo
   app is the reference integration.
+- Docs: a "Tuning the output" guide mapping symptoms to CLI flags and
+  `AnalysisOptions`, a haptics/sound learning-resources section, and a
+  rewritten example walking through audio conversion, loading `.ahap` files,
+  DSL authoring, and analysis tuning.
 
 ## 0.3.0-dev.1
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,23 +1,25 @@
 # Changelog
 
-## 0.3.0-dev.2
+## 0.4.0
 
-- The analyzer now emits time-varying **sharpness curves** (iOS): each
+First stable release. From here, stable versions are released from `main`
+and `-dev.N` prereleases track the `dev` branch on pub.dev.
+
+New capabilities:
+
+- Android primitive compositions: `pattern.toPrimitives()` and the
+  `--formats primitives` CLI output map patterns onto
+  `VibrationEffect.Composition` primitives (click/tick/thud/rises/falls/
+  spin) with scales, delays, and a `minApiLevel`.
+- AHAP parsing: `HapticPattern.fromAhap` tolerantly parses `.ahap` files,
+  and the CLI accepts them as inputs — convert existing iOS haptic
+  libraries to Android formats without re-analyzing audio.
+- The analyzer emits time-varying **sharpness curves** (iOS): each
   continuous segment's brightness (zero-crossing rate) is tracked over time
   and encoded as additive `HapticSharpnessControl` deviations around the
   event's sharpness. Curves are only emitted when the brightness actually
   moves; disable with `--no-sharpness-curves` or
   `AnalysisOptions(sharpnessCurves: false)`.
-- Android conversions now report one `curveParameterUnsupported` warning per
-  parameter type (with a count) instead of one per curve.
-- Roadmap: playback and the Flutter companion package were removed; the demo
-  app is the reference integration.
-- Docs: a "Tuning the output" guide mapping symptoms to CLI flags and
-  `AnalysisOptions`, a haptics/sound learning-resources section, and a
-  rewritten example walking through audio conversion, loading `.ahap` files,
-  DSL authoring, and analysis tuning.
-
-## 0.3.0-dev.1
 
 Accuracy fixes for long and complex sounds:
 
@@ -32,15 +34,16 @@ Accuracy fixes for long and complex sounds:
 - Android waveform amplitudes are sampled at step midpoints, removing the
   half-step lag that dulled ramps.
 
-Roadmap features:
+Polish:
 
-- Android primitive compositions: `pattern.toPrimitives()` and the
-  `--formats primitives` CLI output map patterns onto
-  `VibrationEffect.Composition` primitives (click/tick/thud/rises/falls/
-  spin) with scales, delays, and a `minApiLevel`.
-- AHAP parsing: `HapticPattern.fromAhap` tolerantly parses `.ahap` files,
-  and the CLI accepts them as inputs — convert existing iOS haptic
-  libraries to Android formats without re-analyzing audio.
+- Android conversions report one `curveParameterUnsupported` warning per
+  parameter type (with a count) instead of one per curve.
+- Docs: a "Tuning the output" guide mapping symptoms to CLI flags and
+  `AnalysisOptions`, a haptics/sound learning-resources section, and a
+  rewritten example walking through audio conversion, loading `.ahap` files,
+  DSL authoring, and analysis tuning.
+- Roadmap: playback and the Flutter companion package were removed; the demo
+  app is the reference integration.
 
 ## 0.2.0-dev.4
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,18 @@
 # Changelog
 
+## 0.3.0-dev.2
+
+- The analyzer now emits time-varying **sharpness curves** (iOS): each
+  continuous segment's brightness (zero-crossing rate) is tracked over time
+  and encoded as additive `HapticSharpnessControl` deviations around the
+  event's sharpness. Curves are only emitted when the brightness actually
+  moves; disable with `--no-sharpness-curves` or
+  `AnalysisOptions(sharpnessCurves: false)`.
+- Android conversions now report one `curveParameterUnsupported` warning per
+  parameter type (with a count) instead of one per curve.
+- Roadmap: playback and the Flutter companion package were removed; the demo
+  app is the reference integration.
+
 ## 0.3.0-dev.1
 
 Accuracy fixes for long and complex sounds:

--- a/README.md
+++ b/README.md
@@ -117,6 +117,35 @@ lib/generated/hit_haptic.dart
 a bare `haptify convert` inside a sounds folder writes into that folder.)
 Pass `-o some/dir` to put everything flat into one directory instead.
 
+## Tuning the output
+
+The defaults suit typical sound effects. When the result doesn't feel right,
+adjust by symptom — run with `-v` to see what the analyzer found:
+
+| Symptom | Knob | Direction |
+|---|---|---|
+| Missing taps on drum hits / percussive detail | `--onset-sensitivity` (1.5) | Lower it (e.g. 1.0–1.2) — detects softer onsets |
+| Too many taps, feels like machine-gun buzzing | `--onset-sensitivity` / `--min-gap` (50ms) | Raise sensitivity, or raise the gap to space taps out |
+| Quiet passages barely vibrate | `--gamma` (1.0) | Lower it (e.g. 0.6–0.8) — boosts quiet parts perceptually |
+| Loud parts feel flat / everything at max | `--gamma` | Raise it above 1.0 — spreads the dynamic range down |
+| Background hiss triggers haptics | `--silence-threshold` (0.02) | Raise it — more audio counts as silence |
+| Trailing tails / reverb get cut off | `--silence-threshold` | Lower it |
+| Long clips feel mushy, envelope detail lost | `--curve-rate` (16/s) | Raise it (e.g. 32) — more curve points per second |
+| Files too big for very long audio | `--curve-rate` / `--no-sharpness-curves` | Lower the rate; drop sharpness curves (Android ignores them anyway) |
+| Haptics feel coarse / stair-steppy on Android | `--resolution` (10ms) | Lower it (min 1ms) — finer waveform steps, bigger arrays |
+
+Every flag has a library counterpart on `AnalysisOptions` with the same
+name in camelCase (`onsetSensitivity`, `minOnsetGap`, `gamma`,
+`silenceThreshold`, `curvePointsPerSecond`, `maxCurvePoints`,
+`sharpnessCurves`, `frameSize`), so runtime conversions tune identically:
+
+```dart
+const analyzer = AudioAnalyzer(
+  options: AnalysisOptions(onsetSensitivity: 1.2, gamma: 0.7),
+);
+final pattern = analyzer.analyzeBytes(bytes);
+```
+
 ## How it works
 
 1. **Decode** the audio to mono samples (MP3 decoding is built in via a
@@ -190,6 +219,11 @@ final wf = pattern.toWaveform();    // Android: Vibration.vibrate(
 the UI thread free. Need the decoded samples separately? Call
 `decodeAudioBytes(bytes)` to get `AudioData`, then `analyze` it.
 
+Runtime conversion is the exact same pipeline as the CLI — same analyzer,
+same defaults. Improvements like time-varying sharpness curves and
+duration-scaled envelope budgets apply to uploaded audio automatically, no
+app changes needed.
+
 ## Demo app
 
 The repository contains a Flutter demo app under
@@ -207,6 +241,39 @@ with `cd example_app && flutter run`.
 - ~~Analyzer sharpness curves (iOS)~~ — shipped; sharpness follows the
   sound's brightness over time
 - Preset patterns and an easing/curve library for hand-authoring
+
+## Learn more: haptics & sound
+
+Design guidance:
+
+- [Apple HIG — Playing haptics](https://developer.apple.com/design/human-interface-guidelines/playing-haptics)
+  — when haptics help, when they annoy, and how to pair them with sound
+- [Android — Haptics design principles](https://developer.android.com/develop/ui/views/haptics/haptics-principles)
+  — the Android side of the same story, including the clear/rich/buzzy scale
+
+Platform APIs this package targets:
+
+- [Core Haptics](https://developer.apple.com/documentation/corehaptics) and
+  [Representing haptic patterns in AHAP files](https://developer.apple.com/documentation/corehaptics/representing-haptic-patterns-in-ahap-files)
+  — the AHAP format haptify emits and parses
+- [Android `VibrationEffect`](https://developer.android.com/reference/android/os/VibrationEffect)
+  — `createWaveform` (our waveform JSON) and `startComposition` (our
+  primitives JSON)
+
+Talks & courses:
+
+- WWDC19 — [Introducing Core Haptics](https://developer.apple.com/videos/play/wwdc2019/520/)
+  (intensity/sharpness model, transients vs. continuous)
+- WWDC21 — [Practice audio haptic design](https://developer.apple.com/videos/play/wwdc2021/10278/)
+  (designing haptics *from* sound — exactly what haptify automates)
+- Coursera — [Audio Signal Processing for Music Applications](https://www.coursera.org/learn/audio-signal-processing)
+  (UPF/Stanford; the DSP behind envelopes, onsets, and spectral features)
+- [The Scientist and Engineer's Guide to DSP](https://www.dspguide.com/)
+  — free classic; chapters on convolution and the DFT explain what the
+  analyzer's RMS/ZCR heuristics approximate
+- [musicinformationretrieval.com](https://musicinformationretrieval.com/)
+  — notebooks on onset detection and audio features, directly relevant to
+  how `AudioAnalyzer` works
 
 ## License
 

--- a/README.md
+++ b/README.md
@@ -91,6 +91,9 @@ haptify convert [audio files, globs, or folders] [options]
                            (default 1.0)
     --silence-threshold    Level under which audio counts as silence
                            (default 0.02)
+    --[no-]sharpness-curves
+                           Emit time-varying sharpness curves (iOS); on by
+                           default, disable to shrink files
 -v, --verbose              Print analysis details and conversion warnings
 ```
 
@@ -121,7 +124,8 @@ Pass `-o some/dir` to put everything flat into one directory instead.
    and LAME gapless trimming so timing matches the original audio).
 2. **Analyze**: an RMS loudness envelope is computed per frame; energy-flux
    onset detection finds percussive hits; the zero-crossing rate estimates
-   how *sharp* each moment feels.
+   how *sharp* each moment feels — emitted as a time-varying sharpness curve
+   on iOS when the brightness moves.
 3. **Model**: hits become transient haptic events, sustained passages become
    continuous events shaped by an intensity curve (simplified with
    Ramer-Douglas-Peucker to stay compact).
@@ -200,8 +204,8 @@ with `cd example_app && flutter run`.
   shipped as the `primitives` output format
 - ~~AHAP parsing (`HapticPattern.fromAhap`)~~ — shipped; `.ahap` files
   convert directly to the Android formats
-- Analyzer sharpness curves (iOS): time-varying sharpness that follows the
-  sound's brightness
+- ~~Analyzer sharpness curves (iOS)~~ — shipped; sharpness follows the
+  sound's brightness over time
 - Preset patterns and an easing/curve library for hand-authoring
 
 ## License

--- a/README.md
+++ b/README.md
@@ -200,13 +200,9 @@ with `cd example_app && flutter run`.
   shipped as the `primitives` output format
 - ~~AHAP parsing (`HapticPattern.fromAhap`)~~ — shipped; `.ahap` files
   convert directly to the Android formats
+- Analyzer sharpness curves (iOS): time-varying sharpness that follows the
+  sound's brightness
 - Preset patterns and an easing/curve library for hand-authoring
-- Optional Flutter companion package with playback glue for
-  gaimon / vibration
-
-Audio-to-haptic generation is built in; playback itself (platform channels)
-stays out of scope: haptify authors patterns, your playback plugin plays
-them.
 
 ## License
 

--- a/example/haptify_example.dart
+++ b/example/haptify_example.dart
@@ -1,14 +1,127 @@
+// A guided tour of haptify's library API. Run it from the package root:
+//
+//   dart run example/haptify_example.dart
+//
+// It walks through the four things you can do with haptify:
+//   1. Convert audio (bytes or files) into a haptic pattern
+//   2. Load an existing .ahap file and convert it to Android formats
+//   3. Author a pattern by hand with the DSL
+//   4. Tune the analysis with AnalysisOptions
+//
+// For batch conversion of asset folders, prefer the CLI:
+//   dart run haptify:haptify convert assets/audio
+
+import 'dart:math';
+import 'dart:typed_data';
+
 import 'package:haptify/haptify.dart';
 
-/// Authors a pattern with the DSL and prints both export formats.
-///
-/// To generate patterns from audio files instead, use the CLI:
-/// `dart run haptify:haptify convert assets/audio/*.wav`
 void main() {
+  audioToHaptics();
+  loadAnAhapFile();
+  authorByHand();
+  tuneTheAnalysis();
+}
+
+// ---------------------------------------------------------------------------
+// 1. Audio -> haptics (the runtime path: user uploads, downloads, assets)
+// ---------------------------------------------------------------------------
+
+void audioToHaptics() {
+  banner('1. Convert audio to haptics');
+
+  // Any WAV or MP3 bytes work: a file_picker upload, an HTTP download, a
+  // bundled asset. Here we synthesize a click-then-tone WAV so the example
+  // is self-contained. In an app you would write:
+  //
+  //   final bytes = await pickedFile.readAsBytes();          // Uint8List
+  //   final pattern = const AudioAnalyzer().analyzeBytes(bytes);
+  //
+  // or, with a file path (CLI/server, not web):
+  //
+  //   final audio = await const AudioDecoder().decodeFile('hit.wav');
+  //   final pattern = const AudioAnalyzer().analyze(audio);
+  final bytes = _synthesizeWav();
+  final pattern = const AudioAnalyzer().analyzeBytes(bytes);
+
+  print('Analyzed ${bytes.length} bytes of audio into: '
+      '${pattern.events.whereType<TransientEvent>().length} transient(s), '
+      '${pattern.events.whereType<ContinuousEvent>().length} continuous, '
+      '${pattern.curves.length} curve(s), '
+      '${pattern.totalDuration.inMilliseconds}ms total');
+
+  // One pattern, every target:
+  final ahap = pattern.toAhap(); //         iOS: Gaimon.patternFromData(ahap)
+  final wf =
+      pattern.toWaveform(); //       Android: VibrationEffect.createWaveform
+  final comp = pattern.toPrimitives(); //   Android API 31+: Composition
+
+  print('AHAP document:        ${ahap.length} chars of JSON');
+  print('Android waveform:     ${wf.timings.length} segments '
+      '(timings/amplitudes/repeat: ${wf.timings.take(4).toList()}…)');
+  print('Android composition:  '
+      '${comp.primitives.map((p) => p.primitive.name).join(', ')} '
+      '(needs API ${comp.minApiLevel})');
+
+  // Lossy conversions never throw; they report what they dropped:
+  for (final warning in wf.warnings) {
+    print('waveform warning:     ${warning.message}');
+  }
+}
+
+// ---------------------------------------------------------------------------
+// 2. Load an existing .ahap file (e.g. ported from an iOS project)
+// ---------------------------------------------------------------------------
+
+void loadAnAhapFile() {
+  banner('2. Load an .ahap file');
+
+  // In an app or script you would read the file:
+  //
+  //   final pattern = HapticPattern.fromAhap(
+  //     File('assets/haptics/boom.ahap').readAsStringSync(),
+  //   );
+  //
+  // Parsing is tolerant: audio events are skipped, out-of-range values are
+  // clamped, and missing parameters get the Core Haptics defaults. Here we
+  // parse a document inline:
+  const ahapDocument = '''
+  {
+    "Version": 1.0,
+    "Pattern": [
+      {"Event": {"Time": 0.0, "EventType": "HapticTransient",
+        "EventParameters": [
+          {"ParameterID": "HapticIntensity", "ParameterValue": 1.0},
+          {"ParameterID": "HapticSharpness", "ParameterValue": 0.7}]}},
+      {"Event": {"Time": 0.1, "EventType": "HapticContinuous",
+        "EventDuration": 0.4,
+        "EventParameters": [
+          {"ParameterID": "HapticIntensity", "ParameterValue": 0.8}]}}
+    ]
+  }
+  ''';
+  final pattern = HapticPattern.fromAhap(ahapDocument);
+  print('Parsed ${pattern.events.length} events from AHAP');
+
+  // …and now it converts to the Android formats like any other pattern —
+  // this is how you port an iOS haptic library without touching audio:
+  final wf = pattern.toWaveform();
+  print('As Android waveform:  timings ${wf.timings}, '
+      'amplitudes ${wf.amplitudes}');
+}
+
+// ---------------------------------------------------------------------------
+// 3. Author a pattern by hand with the DSL
+// ---------------------------------------------------------------------------
+
+void authorByHand() {
+  banner('3. Author by hand');
+
+  // Events: transient = a tap; continuous = a sustained rumble with an
+  // attack/decay/release envelope. Durations read naturally: 400.ms, 1.5.s.
   final tap = HapticPattern.events([
     HapticEvent.transient(at: Duration.zero, intensity: 1.0, sharpness: 0.6),
   ]);
-
   final rumble = HapticPattern.events([
     HapticEvent.continuous(
       at: Duration.zero,
@@ -18,20 +131,88 @@ void main() {
       envelope: HapticEnvelope(attack: 50.ms, release: 100.ms),
     ),
   ], curves: [
+    // Curves modulate events over time; intensity control is multiplicative.
     HapticCurve.intensity([
       const CurvePoint(Duration.zero, 0.3),
       CurvePoint(400.ms, 1.0),
     ]),
   ]);
 
-  final combo = tap.then(rumble, gap: 80.ms).repeat(2, gap: 200.ms);
+  // Combinators compose patterns without mutating them:
+  final combo = tap
+      .then(rumble, gap: 80.ms) //   sequence with a silent gap
+      .repeat(2, gap: 200.ms) //     unroll twice
+      .scaleIntensity(0.9); //       soften everything slightly
 
-  print('--- AHAP (iOS, e.g. Gaimon.pattern) ---');
-  print(combo.toAhap());
+  print('Authored ${combo.events.length} events, '
+      '${combo.totalDuration.inMilliseconds}ms');
+  print('First 200 chars of AHAP:\n'
+      '${combo.toAhap().substring(0, 200)}…');
+}
 
-  print('--- Android waveform (e.g. Vibration.vibrate) ---');
-  final wf = combo.toWaveform();
-  print('timings:    ${wf.timings}');
-  print('amplitudes: ${wf.amplitudes}');
-  print('repeat:     ${wf.repeatIndex}');
+// ---------------------------------------------------------------------------
+// 4. Tune the analysis
+// ---------------------------------------------------------------------------
+
+void tuneTheAnalysis() {
+  banner('4. Tune the analysis');
+
+  // Every CLI flag has an AnalysisOptions counterpart. The defaults suit
+  // typical sound effects; see the README's "Tuning the output" section for
+  // which knob fixes which symptom.
+  const custom = AnalysisOptions(
+    onsetSensitivity: 1.2, //   lower -> more taps detected
+    gamma: 0.7, //              <1.0 boosts quiet passages
+    curvePointsPerSecond: 32, // more envelope detail for long sounds
+    sharpnessCurves: true, //   time-varying sharpness on iOS (default)
+  );
+  final pattern =
+      const AudioAnalyzer(options: custom).analyzeBytes(_synthesizeWav());
+  print('With custom options: ${pattern.events.length} events, '
+      '${pattern.curves.length} curves');
+}
+
+// ---------------------------------------------------------------------------
+
+void banner(String title) => print('\n=== $title ===');
+
+/// A 16-bit PCM mono WAV, 700ms: a noise click at 100ms, then a 90Hz tone —
+/// just enough signal for the analyzer to find a tap and a rumble.
+Uint8List _synthesizeWav() {
+  const sampleRate = 44100;
+  final random = Random(7);
+  final samples = List<double>.filled((0.7 * sampleRate).round(), 0);
+  final clickStart = (0.1 * sampleRate).round();
+  for (var i = 0; i < (0.03 * sampleRate).round(); i++) {
+    samples[clickStart + i] = random.nextDouble() * 2 - 1;
+  }
+  final toneStart = (0.25 * sampleRate).round();
+  for (var i = 0; i + toneStart < samples.length; i++) {
+    samples[toneStart + i] = 0.7 * sin(2 * pi * 90 * i / sampleRate);
+  }
+
+  final data = ByteData(44 + samples.length * 2);
+  void putString(int offset, String s) {
+    for (var i = 0; i < s.length; i++) {
+      data.setUint8(offset + i, s.codeUnitAt(i));
+    }
+  }
+
+  putString(0, 'RIFF');
+  data.setUint32(4, 36 + samples.length * 2, Endian.little);
+  putString(8, 'WAVE');
+  putString(12, 'fmt ');
+  data.setUint32(16, 16, Endian.little);
+  data.setUint16(20, 1, Endian.little);
+  data.setUint16(22, 1, Endian.little);
+  data.setUint32(24, sampleRate, Endian.little);
+  data.setUint32(28, sampleRate * 2, Endian.little);
+  data.setUint16(32, 2, Endian.little);
+  data.setUint16(34, 16, Endian.little);
+  putString(36, 'data');
+  data.setUint32(40, samples.length * 2, Endian.little);
+  for (var i = 0; i < samples.length; i++) {
+    data.setInt16(44 + i * 2, (samples[i] * 32767).round(), Endian.little);
+  }
+  return data.buffer.asUint8List();
 }

--- a/lib/src/audio/analyzer.dart
+++ b/lib/src/audio/analyzer.dart
@@ -22,6 +22,7 @@ class AnalysisOptions {
     this.maxCurvePoints = 32,
     this.curvePointsPerSecond = 16,
     this.gamma = 1.0,
+    this.sharpnessCurves = true,
   });
 
   /// The analysis window; also the time resolution of the output.
@@ -56,6 +57,13 @@ class AnalysisOptions {
   /// Perceptual exponent applied to the normalized envelope
   /// (`intensity = envelope^gamma`). Values below 1.0 boost quiet passages.
   final double gamma;
+
+  /// Whether continuous segments also get a time-varying sharpness curve
+  /// following the sound's brightness (zero-crossing rate) over time.
+  ///
+  /// Only iOS can express sharpness, and a curve is only emitted when the
+  /// brightness actually moves; steady sounds keep a single sharpness value.
+  final bool sharpnessCurves;
 }
 
 /// Turns decoded audio into a [HapticPattern]: transient events at detected
@@ -119,25 +127,26 @@ class AudioAnalyzer {
       if (length < 3) continue;
 
       var peak = 0.0;
-      var zcrSum = 0.0;
       for (var i = segment.start; i < segment.end; i++) {
         peak = max(peak, envelope[i]);
-        zcrSum += frames[i].zeroCrossingRate;
       }
+
+      // Per-frame sharpness, smoothed so a curve spends its point budget on
+      // real brightness changes rather than frame jitter.
+      final sharpnessSeries = _smooth([
+        for (var i = segment.start; i < segment.end; i++)
+          _sharpness(frames[i].zeroCrossingRate),
+      ]);
+      final meanSharpness =
+          sharpnessSeries.reduce((a, b) => a + b) / sharpnessSeries.length;
 
       events.add(HapticEvent.continuous(
         at: frameTime(segment.start),
         duration: frameTime(length),
         intensity: peak.clamp(0.0, 1.0),
-        sharpness: _sharpness(zcrSum / length),
+        sharpness: meanSharpness.clamp(0.0, 1.0),
       ));
 
-      // The intensity curve traces the envelope, normalized so the event's
-      // intensity is the ceiling.
-      final points = <CurvePoint>[
-        for (var i = segment.start; i < segment.end; i++)
-          CurvePoint(frameTime(i), (envelope[i] / peak).clamp(0.0, 1.0)),
-      ];
       // The point budget scales with the segment length so long, complex
       // sounds keep their envelope detail.
       final seconds =
@@ -146,7 +155,32 @@ class AudioAnalyzer {
         options.maxCurvePoints,
         (seconds * options.curvePointsPerSecond).ceil(),
       );
+
+      // The intensity curve traces the envelope, normalized so the event's
+      // intensity is the ceiling.
+      final points = <CurvePoint>[
+        for (var i = segment.start; i < segment.end; i++)
+          CurvePoint(frameTime(i), (envelope[i] / peak).clamp(0.0, 1.0)),
+      ];
       curves.add(HapticCurve.intensity(_simplify(points, budget)));
+
+      // Sharpness curve: additive deviations from the event's sharpness
+      // (AHAP's HapticSharpnessControl semantics), emitted only when the
+      // brightness actually moves over the segment.
+      if (options.sharpnessCurves) {
+        var maxDeviation = 0.0;
+        final sharpnessPoints = <CurvePoint>[];
+        for (var i = 0; i < sharpnessSeries.length; i++) {
+          final deviation =
+              (sharpnessSeries[i] - meanSharpness).clamp(-1.0, 1.0);
+          maxDeviation = max(maxDeviation, deviation.abs());
+          sharpnessPoints
+              .add(CurvePoint(frameTime(segment.start + i), deviation));
+        }
+        if (maxDeviation >= _minSharpnessDeviation) {
+          curves.add(HapticCurve.sharpness(_simplify(sharpnessPoints, budget)));
+        }
+      }
     }
 
     return HapticPattern(events: events, curves: curves);
@@ -261,6 +295,27 @@ class AudioAnalyzer {
   /// near 0, noise and bright transients near 1.
   static double _sharpness(double zeroCrossingRate) =>
       sqrt((zeroCrossingRate / 0.5).clamp(0.0, 1.0));
+
+  /// A sharpness swing smaller than this is treated as steady: no curve is
+  /// emitted, keeping files small and Android conversions warning-free.
+  static const double _minSharpnessDeviation = 0.08;
+
+  /// Centered moving average over a five-sample window.
+  static List<double> _smooth(List<double> values) {
+    if (values.length < 3) return values;
+    const half = 2;
+    final smoothed = List<double>.filled(values.length, 0);
+    for (var i = 0; i < values.length; i++) {
+      final lo = max(0, i - half);
+      final hi = min(values.length, i + half + 1);
+      var sum = 0.0;
+      for (var j = lo; j < hi; j++) {
+        sum += values[j];
+      }
+      smoothed[i] = sum / (hi - lo);
+    }
+    return smoothed;
+  }
 
   /// Ramer–Douglas–Peucker curve simplification fitted to [maxPoints].
   ///

--- a/lib/src/cli/convert_command.dart
+++ b/lib/src/cli/convert_command.dart
@@ -84,6 +84,12 @@ class ConvertCommand extends Command<int> {
         help: 'Envelope level under which audio counts as silence (0-1).',
       )
       ..addFlag(
+        'sharpness-curves',
+        defaultsTo: true,
+        help: 'Emit time-varying sharpness curves following the sound\'s '
+            'brightness (iOS only); --no-sharpness-curves shrinks files.',
+      )
+      ..addFlag(
         'verbose',
         abbr: 'v',
         negatable: false,
@@ -132,6 +138,7 @@ class ConvertCommand extends Command<int> {
       gamma: _doubleArg(args.option('gamma')!, 'gamma'),
       silenceThreshold:
           _doubleArg(args.option('silence-threshold')!, 'silence-threshold'),
+      sharpnessCurves: args.flag('sharpness-curves'),
     );
 
     var failures = 0;

--- a/lib/src/encoders/primitives/primitives_encoder.dart
+++ b/lib/src/encoders/primitives/primitives_encoder.dart
@@ -37,15 +37,22 @@ class PrimitivesEncoder {
   /// Renders [pattern] into an ordered primitive composition.
   PrimitiveComposition encode(HapticPattern pattern) {
     final warnings = <ConversionWarning>[];
+    // One warning per unsupported parameter type, not per curve — analyzer
+    // output can carry one sharpness curve per segment.
+    final unsupportedCounts = <HapticCurveParameter, int>{};
     for (final curve in pattern.curves) {
       if (curve.parameter != HapticCurveParameter.intensityControl) {
-        warnings.add(ConversionWarning(
-          ConversionWarningCode.curveParameterUnsupported,
-          'Compositions cannot express ${curve.parameter.name} curves; '
-          'the curve was ignored.',
-        ));
+        unsupportedCounts.update(curve.parameter, (n) => n + 1,
+            ifAbsent: () => 1);
       }
     }
+    unsupportedCounts.forEach((parameter, count) {
+      warnings.add(ConversionWarning(
+        ConversionWarningCode.curveParameterUnsupported,
+        'Compositions cannot express ${parameter.name} curves; '
+        '$count ${count == 1 ? 'curve was' : 'curves were'} ignored.',
+      ));
+    });
     if (pattern.repeatFrom != null) {
       warnings.add(const ConversionWarning(
         ConversionWarningCode.loopUnsupported,

--- a/lib/src/encoders/waveform/waveform_encoder.dart
+++ b/lib/src/encoders/waveform/waveform_encoder.dart
@@ -31,15 +31,22 @@ class WaveformEncoder {
     }
 
     final warnings = <ConversionWarning>[];
+    // One warning per unsupported parameter type, not per curve — analyzer
+    // output can carry one sharpness curve per segment.
+    final unsupportedCounts = <HapticCurveParameter, int>{};
     for (final curve in pattern.curves) {
       if (curve.parameter != HapticCurveParameter.intensityControl) {
-        warnings.add(ConversionWarning(
-          ConversionWarningCode.curveParameterUnsupported,
-          'Android waveforms cannot express ${curve.parameter.name} curves; '
-          'the curve was ignored.',
-        ));
+        unsupportedCounts.update(curve.parameter, (n) => n + 1,
+            ifAbsent: () => 1);
       }
     }
+    unsupportedCounts.forEach((parameter, count) {
+      warnings.add(ConversionWarning(
+        ConversionWarningCode.curveParameterUnsupported,
+        'Android waveforms cannot express ${parameter.name} curves; '
+        '$count ${count == 1 ? 'curve was' : 'curves were'} ignored.',
+      ));
+    });
     if (_hasOverlaps(pattern)) {
       warnings.add(const ConversionWarning(
         ConversionWarningCode.overlappingEventsMerged,

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -2,7 +2,7 @@ name: haptify
 description: >-
   Generate haptic feedback files from audio: .ahap for iOS Core Haptics plus
   Android waveforms, via a CLI or a composable Dart pattern API.
-version: 0.3.0-dev.2
+version: 0.4.0
 repository: https://github.com/imedboumalek/haptify
 issue_tracker: https://github.com/imedboumalek/haptify/issues
 topics:

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -2,7 +2,7 @@ name: haptify
 description: >-
   Generate haptic feedback files from audio: .ahap for iOS Core Haptics plus
   Android waveforms, via a CLI or a composable Dart pattern API.
-version: 0.3.0-dev.1
+version: 0.3.0-dev.2
 repository: https://github.com/imedboumalek/haptify
 issue_tracker: https://github.com/imedboumalek/haptify/issues
 topics:

--- a/test/analyzer_test.dart
+++ b/test/analyzer_test.dart
@@ -1,5 +1,6 @@
 import 'dart:math';
 
+import 'package:collection/collection.dart';
 import 'package:haptify/haptify.dart';
 import 'package:test/test.dart';
 
@@ -160,6 +161,71 @@ void main() {
     final continuous = pattern.events.whereType<ContinuousEvent>().toList();
     expect(continuous, hasLength(2));
     expect(continuous[1].time.inMilliseconds, closeTo(700, 30));
+  });
+
+  group('sharpness curves', () {
+    /// One second with no silence gap: dull 90Hz sine for the first half,
+    /// bright white noise at matched RMS for the second — a brightness sweep
+    /// within a single continuous segment.
+    List<double> brightnessSweep() {
+      final random = Random(5);
+      const amplitude = 0.6; // sine amplitude; RMS = 0.6/sqrt(2)
+      final noiseAmplitude = amplitude / sqrt(2) * sqrt(3); // match RMS
+      return [
+        ...tone(frequency: 90, seconds: 0.5, amplitude: amplitude),
+        for (var i = 0; i < (0.5 * sampleRate).round(); i++)
+          noiseAmplitude * (random.nextDouble() * 2 - 1),
+      ];
+    }
+
+    test('a brightness sweep gets a rising sharpness curve', () {
+      final pattern = analyzer.analyze(audioFrom(brightnessSweep()));
+      final curve = pattern.curves
+          .where((c) => c.parameter == HapticCurveParameter.sharpnessControl)
+          .single;
+      // Deviations are additive around the event's mean sharpness: dull
+      // opening below the mean, bright ending above it.
+      expect(curve.points.first.value, lessThan(-0.05));
+      expect(curve.points.last.value, greaterThan(0.05));
+
+      // The event's own sharpness sits between the two extremes.
+      final event = pattern.events.whereType<ContinuousEvent>().single;
+      expect(event.sharpness, greaterThan(0.1));
+      expect(event.sharpness, lessThan(0.9));
+    });
+
+    test('a steady tone emits no sharpness curve', () {
+      final pattern = analyzer.analyze(
+        audioFrom(tone(frequency: 80, seconds: 0.5)),
+      );
+      expect(
+        pattern.curves
+            .where((c) => c.parameter == HapticCurveParameter.sharpnessControl),
+        isEmpty,
+      );
+    });
+
+    test('sharpnessCurves: false disables emission', () {
+      final pattern = const AudioAnalyzer(
+        options: AnalysisOptions(sharpnessCurves: false),
+      ).analyze(audioFrom(brightnessSweep()));
+      expect(
+        pattern.curves
+            .where((c) => c.parameter == HapticCurveParameter.sharpnessControl),
+        isEmpty,
+      );
+    });
+
+    test('patterns with sharpness curves are an AHAP encoder fixed point', () {
+      final pattern = analyzer.analyze(audioFrom(brightnessSweep()));
+      final encoded = pattern.toAhapMap();
+      final reEncoded = HapticPattern.fromAhap(pattern.toAhap()).toAhapMap();
+      expect(
+        const DeepCollectionEquality().equals(reEncoded, encoded),
+        isTrue,
+        reason: 'decode(encode(p)) must re-encode identically',
+      );
+    });
   });
 
   test('the pattern renders to both targets without errors', () {

--- a/test/waveform_encoder_test.dart
+++ b/test/waveform_encoder_test.dart
@@ -98,6 +98,24 @@ void main() {
           ConversionWarningCode.curveParameterUnsupported);
     });
 
+    test('repeated unsupported curves warn once per parameter type', () {
+      final pattern = HapticPattern(
+        events: [
+          HapticEvent.continuous(at: Duration.zero, duration: 900.ms),
+        ],
+        curves: [
+          HapticCurve.sharpness([const CurvePoint(Duration.zero, 0.5)]),
+          HapticCurve.sharpness([CurvePoint(300.ms, -0.2)]),
+          HapticCurve.sharpness([CurvePoint(600.ms, 0.1)]),
+        ],
+      );
+      final wf = pattern.toWaveform();
+      expect(wf.warnings, hasLength(1));
+      expect(wf.warnings.single.code,
+          ConversionWarningCode.curveParameterUnsupported);
+      expect(wf.warnings.single.message, contains('3 curves'));
+    });
+
     test('overlapping events merge with max and warn', () {
       final pattern = HapticPattern.events([
         HapticEvent.continuous(


### PR DESCRIPTION
## Summary
First stable release. Everything since 0.2.0-dev.4 (the 0.3.0-dev previews were never published):

- Analyzer sharpness curves (iOS): time-varying brightness tracking as `HapticSharpnessControl` deviations
- Android primitive compositions (`toPrimitives`, `--formats primitives`) and AHAP parsing (`fromAhap`, `.ahap` CLI inputs)
- Accuracy fixes: AHAP curve-relative control point times, duration-scaled curve budgets (`--curve-rate`), midpoint waveform sampling
- Docs: tuning guide (symptom → knob), haptics/sound learning resources, rewritten guided example
- CI fixed (package job scoped; dedicated Flutter demo-app job) and new branch strategy: feat/* → dev (auto dev prereleases) → main (stable tags)
- Roadmap: playback removed; version graduated to stable 0.4.0

## Release steps after merge
Tag `v0.4.0` on main — the tag-triggered workflow publishes to pub.dev via OIDC.

## Test plan
- [x] CI green on dev (package matrix + Flutter demo app)
- [x] 144 package tests, 3 app tests
- [x] `dart pub publish --dry-run` validates as 0.4.0
- [x] Dev-prerelease workflow verified live: correctly skips stable versions